### PR TITLE
Sette loggdestinasjonar eksplisitt

### DIFF
--- a/.nais/nais-dev.yaml
+++ b/.nais/nais-dev.yaml
@@ -55,12 +55,15 @@ spec:
       external:
         - host: axsys.dev-fss-pub.nais.io
         - host: team-obo-unleash-api.nav.cloud.nais.io
-
+  observability:
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   env:
     - name: AXSYS_URL
       value: https://axsys.dev-fss-pub.nais.io
     - name: AXSYS_SCOPE
       value: api://dev-fss.org.axsys/.default
-
   envFrom:
     - secret: obo-unleash-api-token

--- a/.nais/nais-prod.yaml
+++ b/.nais/nais-prod.yaml
@@ -55,12 +55,15 @@ spec:
       external:
         - host: axsys.prod-fss-pub.nais.io
         - host: team-obo-unleash-api.nav.cloud.nais.io
-
+  observability:
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   env:
     - name: AXSYS_URL
       value: https://axsys.prod-fss-pub.nais.io
     - name: AXSYS_SCOPE
       value: api://prod-fss.org.axsys/.default
-
   envFrom:
     - secret: obo-unleash-api-token


### PR DESCRIPTION
[Nais skal/har gått over til Grafana Loki som default loggverktøy og Elastic Kibana er difor deprekert](https://nav-it.slack.com/docs/T5LNAMWNA/F08RNSRJ934). Elastic vil vere tilgjengeleg ut året, så inntil vi får migrert til Grafana Loki, må vi eksplisitt spesifisere Elastic Kibana som loggdestinasjon. Legg difor til både `elastic` og `loki` som loggdestinasjonar slik at vi kan halde fram med å få loggar i Kibana. Når vi er blitt vande nok med Loki kan vi gå over permanent og fjerne `elastic`.